### PR TITLE
fix imports and batching for plone4.3

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-- Plone 4.3 compatibile [sureshvv]
+- Plone 4.3 compatibility [sureshvv, fRiSi]
 
 1.0 - April 9, 2014
 -------------------

--- a/src/collective/notices/browser/traversal.py
+++ b/src/collective/notices/browser/traversal.py
@@ -1,5 +1,5 @@
 from zope.component import getUtility
-from zope.app.component.hooks import getSite
+from zope.component.hooks import getSite
 
 from zope.traversing.interfaces import ITraversable
 from zope.publisher.interfaces.http import IHTTPRequest
@@ -20,7 +20,7 @@ from ..interfaces import INoticesStorage
 class NoticesNamespace(grok.MultiAdapter):
     """Used to traverse to a notice.
     """
-    
+
     grok.adapts(ISiteRoot, IHTTPRequest)
     grok.provides(ITraversable)
     grok.name('notices')
@@ -39,7 +39,7 @@ class NoticesNamespace(grok.MultiAdapter):
 class NoticesStorageTraverser(ContainerTraverser, grok.MultiAdapter):
     """A traverser for INoticesStorage, that is acqusition-aware
     """
-    
+
     grok.adapts(INoticesStorage, IBrowserRequest)
     grok.provides(IBrowserPublisher)
 


### PR DESCRIPTION
normally, a plone4.3 instance would not start up without the import fixes done in this pull request.

also, the plone.batching batch implementation required the catalog result set to provide the __getitem__ method.

in addition i noticed, that the batch navigation based on CrudBatchView did not work properly:
it passes page=1 for the first page, and our batch initialization wants this to be 0.
instead of initializing the batch with `start=(page-1) * batch_size` i used BatchView directly as it has been done before (so our view does not break when CrudBatchView is changed)